### PR TITLE
Hotfix/registro productos

### DIFF
--- a/Backend/inventario/src/commands/create_producto.py
+++ b/Backend/inventario/src/commands/create_producto.py
@@ -14,7 +14,7 @@ class CreateProductoSchema(Schema):
     nombre = fields.Str(required=True)
     descripcion = fields.Str(required=True)
     perecedero = fields.Bool(required=True)
-    fechaVencimiento = fields.DateTime(required=True)
+    fechaVencimiento = fields.DateTime(required=False)
     valorUnidad = fields.Float(required=True)
     tiempoEntrega = fields.DateTime(required=True)
     condicionAlmacenamiento = fields.Str(required=True)
@@ -31,6 +31,13 @@ class CreateProductoSchema(Schema):
             Categoria[categoria_str]
         except KeyError:
             raise ValidationError(f"Categoría inválida. Opciones válidas: {', '.join([c.name for c in Categoria])}")
+            
+    @validates_schema
+    def validate_fecha_vencimiento(self, data, **kwargs):
+        # Se valida que si se tiene sleccionado que el producto es perecedero se solicite la fecha
+        if data.get("perecedero") and "fechaVencimiento" not in data:
+            raise ValidationError({"fechaVencimiento": ["La fecha de vencimiento es requerida para productos perecederos"]})
+    
 
 
 class Create(BaseCommand):
@@ -52,12 +59,14 @@ class Create(BaseCommand):
                 return {"error": "El producto ya existe para este fabricante"}, 400
 
             # Se instancia un nuevo producto
+            fecha_vencimiento = schema.get('fechaVencimiento') if schema.get('perecedero') else None
+            
             nuevo_producto = Producto(
                 sku=sku,
                 nombre=schema['nombre'],
                 descripcion=schema['descripcion'],
                 perecedero=schema['perecedero'],
-                fechaVencimiento=schema['fechaVencimiento'],
+                fechaVencimiento=fecha_vencimiento,
                 valorUnidad=schema['valorUnidad'],
                 tiempoEntrega=schema['tiempoEntrega'],
                 condicionAlmacenamiento=schema['condicionAlmacenamiento'],

--- a/Backend/inventario/src/commands/create_producto.py
+++ b/Backend/inventario/src/commands/create_producto.py
@@ -14,7 +14,7 @@ class CreateProductoSchema(Schema):
     nombre = fields.Str(required=True)
     descripcion = fields.Str(required=True)
     perecedero = fields.Bool(required=True)
-    fechaVencimiento = fields.DateTime(required=False)
+    fechaVencimiento = fields.DateTime(required=False, allow_none=True)
     valorUnidad = fields.Float(required=True)
     tiempoEntrega = fields.DateTime(required=True)
     condicionAlmacenamiento = fields.Str(required=True)

--- a/Backend/inventario/src/models/producto.py
+++ b/Backend/inventario/src/models/producto.py
@@ -18,7 +18,7 @@ class Producto(Base, Model):
     nombre = Column(String, nullable=False)
     descripcion = Column(String, nullable=False)
     perecedero = Column(Boolean, nullable=False)
-    fechaVencimiento = Column(DateTime, nullable=False)
+    fechaVencimiento = Column(DateTime, nullable=True)
     valorUnidad = Column(Float, nullable=False)
     tiempoEntrega = Column(DateTime, nullable=False)
     condicionAlmacenamiento = Column(String, nullable=False)

--- a/WebApp/src/app/core/services/productos.services.ts
+++ b/WebApp/src/app/core/services/productos.services.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable,inject } from "@angular/core";
 import { environment } from '../../../environment/environment';
-import { Producto } from "../../features/private/productos/models/producto";
+import { Producto, Categoria } from "../../features/private/productos/models/producto";
 interface ProductoResponse {
   createdAt: string;
     sku:string;
@@ -19,11 +19,26 @@ export class ProductoService{
     const fechaVencimiento = producto.perecedero ? new Date(producto.fechaVencimiento).toISOString() : null;
     const tiempoEntrega = new Date(producto.tiempoEntrega).toISOString();
     
+    // Transformar el valor de la categoría al formato que espera el backend
+    // Necesitamos enviar el nombre del enum, no el valor
+    let categoriaTransformada = producto.categoria;
+    
+    // Mapeo de valores de categoría a las claves de enum esperadas por el backend
+    const categoriasMap: Record<string, Categoria> = {
+      'ALIMENTOS Y BEBIDAS': Categoria.ALIMENTOS_BEBIDAS,
+      'CUIDADO PERSONAL': Categoria.CUIDADO_PERSONAL,
+      'LIMPIEZA Y HOGAR': Categoria.LIMPIEZA_HOGAR,
+      'BEBÉS': Categoria.BEBES,
+      'MASCOTAS': Categoria.MASCOTAS
+    };
+    
     const productoData = {
       ...rest,
       fechaVencimiento: fechaVencimiento,
       tiempoEntrega: tiempoEntrega,
-      fabricante_id: fabricanteId
+      fabricante_id: fabricanteId,
+      // Enviar el nombre del enum para que haga match de la manera en que está en el backend
+      categoria: Object.keys(Categoria).find(key => Categoria[key as keyof typeof Categoria] === producto.categoria) || producto.categoria
     };
     
     console.log('Datos enviados al backend:', productoData);


### PR DESCRIPTION
Ajustado front para que los valores de categoría coinicidan exactamente con el enum  del modelo sin espacios en blanco y evitar error
Ajuste para que requiera fecha de vencimiento solo cuando se selecciona que el producto es perecedero y el back permita este valor en null de no ser el caso
